### PR TITLE
[#6] Align TTS voice safety rules and public audio publishing docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 ## Session Context (echo at the top of substantive responses)
 
 - **Session Name:** `assembly-voice`
-- **Environment:** `gmusic@eury.ferret-harmonic.ts.net` (PWD: `/home/gmusic/workspace/assembly-voice`)
+- **Environment:** `gmusic@eury.ferret-harmonic.ts.net` (PWD: `/home/gmusic/salix/repos/assembly-voice`)
 - **SSH Route:** `ssh gmusic@eury.ferret-harmonic.ts.net`
-- **SSH Interactive:** `ssh -t gmusic@eury.ferret-harmonic.ts.net "cd /home/gmusic/workspace/assembly-voice && exec bash"`
-- **Listening Portal:** `https://eury.ferret-harmonic.ts.net:4444/`
+- **SSH Interactive:** `ssh -t gmusic@eury.ferret-harmonic.ts.net "cd /home/gmusic/salix/repos/assembly-voice && exec bash"`
+- **Listening Portal:** `https://gmusicassembly.com/Assembly/voice/`
 
 ## Mandatory TTS Generation
 
@@ -24,17 +24,18 @@ python3 scripts/tts-generate.py --text "<concise version of response>" --lang <e
 After generation, include in the response:
 
 ```
-🔊 https://eury.ferret-harmonic.ts.net:4444/audio/<filename-from-script-output>
+🔊 https://gmusicassembly.com/Assembly/voice/audio/<filename-from-script-output>
 ```
 
-The filename is in the script's `audio=...` line — copy the basename (e.g. `20260502_173947_fr.mp3`).
+The filename is in the script's `audio=...` or `public_url=...` line — copy the basename (e.g. `20260502_173947_fr.mp3`).
 
 ### Parameters
 
 - `--text`: A **concise spoken version** of the response. For long outputs, summarize to ~1–3 sentences.
   Avoid Markdown, emoji, code blocks — those don't speak well.
 - `--lang`: `fr` if the user wrote in French, `en` if in English. When mixed, follow the dominant language.
-- `--persona` (optional): override default mapping (`fr → aureon`, `en → nyro`). Use when a specific Assembly voice is more fitting (e.g. `--persona synth` for execution/orchestration messages).
+- `--persona` (optional): override default mapping (`fr → aureon`, `en → nyro`).
+- **Voice safety rule:** In `tts-generate.py`, persona selection controls the actual voice. For French audio, default to French-speaking personas (`aureon` or `salix`). Only use English-speaking personas (`nyro`, `jamai`, `synth`) when the user explicitly wants that agent's configured voice identity preserved.
 
 ### When to skip TTS
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,15 +4,17 @@
 - **Session Context:**
   - **Session Name:** `assembly-voice`
   - **Checkpoint Command:** `/resume save assembly-voice-checkpoint`
-  - **Environment:** `gmusic@eury.ferret-harmonic.ts.net` (PWD: `/home/gmusic/workspace/assembly-voice`)
+  - **Environment:** `gmusic@eury.ferret-harmonic.ts.net` (PWD: `/home/gmusic/salix/repos/assembly-voice`)
   - **SSH Route:** `ssh gmusic@eury.ferret-harmonic.ts.net`
-  - **SSH Interactive:** `ssh -t gmusic@eury.ferret-harmonic.ts.net "cd /home/gmusic/workspace/assembly-voice && exec bash"`
+  - **SSH Interactive:** `ssh -t gmusic@eury.ferret-harmonic.ts.net "cd /home/gmusic/salix/repos/assembly-voice && exec bash"`
 - **Mandatory TTS Generation:** Every time you provide a text response to the user, you MUST also execute the text-to-speech generation script using `run_shell_command`.
 - **Command:** `python scripts/tts-generate.py --text "<response_text>" --lang <lang_code>`
-- **Audio Web Link:** After generating the audio, you MUST provide the web link in your response following this format: `https://eury.ferret-harmonic.ts.net:4444/audio/<filename>`
+- **Audio Web Link:** After generating the audio, you MUST provide the web link in your response following this format: `https://gmusicassembly.com/Assembly/voice/audio/<filename>`
 - **Parameters:**
   - `--text`: The exact text of your response (concise versions are preferred for long outputs).
   - `--lang`: Set to `en` for English or `fr` for French, matching the response language.
+  - `--persona` (optional): Select a specific Assembly voice identity when needed.
+  - **Voice safety rule:** persona selection controls the actual voice. For French audio, default to French-speaking personas (`aureon` or `salix`). Only use English-speaking personas (`nyro`, `jamai`, `synth`) when the user explicitly wants that agent's configured voice identity preserved.
 
 
 ## Voice Personas (Edge-TTS)

--- a/scripts/tts-generate.py
+++ b/scripts/tts-generate.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import edge_tts
 
 ROOT = Path(__file__).resolve().parent.parent
+PUBLIC_AUDIO_BASE = "https://gmusicassembly.com/Assembly/voice/audio"
 AUDIO_DIR = ROOT / "audio"
 MESSAGES_FILE = ROOT / "messages.json"
 
@@ -93,6 +94,7 @@ async def amain() -> int:
     print(f"OK  id={entry['id']}")
     print(f"    persona={persona}  lang={lang}  voice={voice}")
     print(f"    audio={out_path}  bytes={size}")
+    print(f"    public_url={PUBLIC_AUDIO_BASE}/{fname}")
     return 0
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- align `CLAUDE.md` and `GEMINI.md` around TTS voice-safety behavior
- document the production listening portal/public audio URL
- make `scripts/tts-generate.py` print a `public_url` line

## Test Plan
- `python3 -m py_compile scripts/tts-generate.py`

Closes #6
