### PR TITLE
fix: stop messages.json from being erased by an ordinary write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ __pycache__/
 # Runtime artifacts (TTS portal)
 audio/
 messages.json
+
+# Manifest backups — same reason messages.json is ignored: it is voice DATA,
+# not source. Rotated by scripts/manifest_store.py and lib/manifest-store.js.
+backups/

--- a/lib/manifest-store.js
+++ b/lib/manifest-store.js
@@ -1,0 +1,170 @@
+'use strict';
+
+/**
+ * Safe read/modify/write for messages.json — the Node half.
+ *
+ * This is the mirror of scripts/manifest_store.py. Two processes in two
+ * languages write this file: the Python publisher appends messages, and this
+ * server marks them listened. Before 2026-08-08 both did the same unsafe thing:
+ *
+ *     catch (e) { return { messages: [] }; }      // substitute empty
+ *     fs.writeFileSync(MESSAGES_FILE, ...)        // then truncate
+ *
+ * A torn file therefore erased the history on the next ordinary operation —
+ * a publish, or a listener simply tapping "listened". 407 records, untracked
+ * by git, one interrupted write from gone.
+ *
+ * The three rules, identical to the Python side:
+ *   1. a corrupt manifest is never "empty" — refuse, never invent
+ *   2. writes are atomic — temp file, fsync, rename
+ *   3. writers take a lock, and it is an O_EXCL sentinel rather than flock so
+ *      that Python and Node actually exclude each other
+ *
+ * LOCK_SUFFIX and LOCK_STALE_MS must match manifest_store.py or the two
+ * languages will hold different locks and serialise nothing.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const LOCK_SUFFIX = '.lock';
+const LOCK_STALE_MS = 30_000;
+const LOCK_TIMEOUT_MS = 10_000;
+const LOCK_POLL_MS = 50;
+
+const BACKUP_DIRNAME = 'backups';
+const BACKUP_KEEP = 30;
+
+class ManifestCorrupt extends Error {}
+class ManifestLocked extends Error {}
+
+const lockPath = (file) => file + LOCK_SUFFIX;
+
+/** Busy-wait for the lock. Synchronous on purpose: the callers are already sync. */
+function acquireLock(file, timeoutMs = LOCK_TIMEOUT_MS) {
+  const lock = lockPath(file);
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    try {
+      const fd = fs.openSync(lock, 'wx');       // O_CREAT|O_EXCL
+      fs.writeSync(fd, `${process.pid} ${Date.now() / 1000}\n`);
+      fs.closeSync(fd);
+      return lock;
+    } catch (e) {
+      if (e.code !== 'EEXIST') throw e;
+      // A crashed writer must not wedge the portal forever.
+      try {
+        if (Date.now() - fs.statSync(lock).mtimeMs > LOCK_STALE_MS) {
+          try { fs.unlinkSync(lock); } catch (_) {}
+          continue;
+        }
+      } catch (_) {
+        continue; // released while we looked
+      }
+      if (Date.now() >= deadline) {
+        throw new ManifestLocked(`another writer has held ${path.basename(lock)} for over ${timeoutMs}ms`);
+      }
+      // Sleep without async: Atomics.wait on a throwaway buffer.
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, LOCK_POLL_MS);
+    }
+  }
+}
+
+function releaseLock(lock) {
+  try { fs.unlinkSync(lock); } catch (_) {}
+}
+
+/** Parse, or throw. An absent file is legitimately empty; an unreadable one is not. */
+function readManifest(file) {
+  if (!fs.existsSync(file)) return { messages: [] };
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch (e) {
+    throw new ManifestCorrupt(`${file} could not be read (${e.message})`);
+  }
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (e) {
+    throw new ManifestCorrupt(
+      `${file} exists but did not parse (${e.message}). Refusing to write — ` +
+      `doing so would replace the history with an empty file.`
+    );
+  }
+  if (!data || !Array.isArray(data.messages)) {
+    throw new ManifestCorrupt(`${file} parsed but is not a manifest.`);
+  }
+  return data;
+}
+
+/** Keep a daily copy. Best effort — a backup failure must never fail an operation. */
+function rotateBackup(file) {
+  try {
+    const dir = path.join(path.dirname(file), BACKUP_DIRNAME);
+    fs.mkdirSync(dir, { recursive: true });
+    const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    const daily = path.join(dir, `messages.${stamp}.json`);
+    if (!fs.existsSync(daily) && fs.existsSync(file)) {
+      fs.copyFileSync(file, daily);
+      const all = fs.readdirSync(dir).filter((f) => /^messages\..*\.json$/.test(f)).sort();
+      for (const old of all.slice(0, Math.max(0, all.length - BACKUP_KEEP))) {
+        try { fs.unlinkSync(path.join(dir, old)); } catch (_) {}
+      }
+    }
+  } catch (_) {}
+}
+
+/** Replace the manifest atomically. Caller must hold the lock. */
+function writeManifest(file, data) {
+  if (!data || !Array.isArray(data.messages)) {
+    throw new Error('refusing to write a manifest without a messages array');
+  }
+  rotateBackup(file);
+
+  const tmp = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.tmp`);
+  try {
+    const fd = fs.openSync(tmp, 'w');
+    try {
+      fs.writeSync(fd, JSON.stringify(data, null, 2) + '\n');
+      fs.fsyncSync(fd);            // bytes on disk before the rename
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(tmp, file);      // atomic within the directory
+  } finally {
+    try { fs.unlinkSync(tmp); } catch (_) {}
+  }
+
+  try {                            // durably record the rename itself
+    const dfd = fs.openSync(path.dirname(file), 'r');
+    try { fs.fsyncSync(dfd); } finally { fs.closeSync(dfd); }
+  } catch (_) {}
+}
+
+/**
+ * Read, mutate, write — all under one lock.
+ * `mutate(data)` returns true to commit, false to leave the file untouched.
+ */
+function updateManifest(file, mutate) {
+  const lock = acquireLock(file);
+  try {
+    const data = readManifest(file);
+    if (mutate(data) === false) return data;
+    writeManifest(file, data);
+    return data;
+  } finally {
+    releaseLock(lock);
+  }
+}
+
+module.exports = {
+  ManifestCorrupt,
+  ManifestLocked,
+  acquireLock,
+  releaseLock,
+  readManifest,
+  writeManifest,
+  updateManifest,
+};

--- a/scripts/manifest_store.py
+++ b/scripts/manifest_store.py
@@ -1,0 +1,179 @@
+"""Safe read/modify/write for messages.json.
+
+WHY THIS EXISTS. On 2026-08-08 the manifest held 407 messages going back to
+2026-05-02. It is in .gitignore and untracked, so git has never seen a single
+one of them, and both writers shared the same two-step defect:
+
+    except Exception:  manifest = {"messages": []}     # substitute empty
+    open(MESSAGES_FILE, "w")                           # then truncate
+
+One interrupted write leaves a torn file. The next publish parses it, fails,
+silently starts from an empty manifest, and overwrites. 407 records gone,
+exit code 0, the word "OK" printed. Reproduced: 101 records became 1. Under
+eight concurrent publishers, 101 became 4 — the losers each read the file while
+a winner had it truncated.
+
+Three rules follow, and this module exists to make them unavoidable:
+
+  1. A CORRUPT MANIFEST IS NEVER "EMPTY". Refuse loudly. An empty manifest is a
+     claim that nothing was ever said, and this file cannot make that claim.
+  2. WRITES ARE ATOMIC. Write a sibling temp file, fsync it, then os.replace —
+     a rename within a directory either happens or does not. A reader never
+     sees a half-written manifest, so rule 1 stops being reachable at all.
+  3. WRITERS TAKE A LOCK. server.js writes this file too. The lock is an
+     O_EXCL sentinel rather than flock so both languages can hold the same one.
+
+`server.js` has a mirror of this in lib/manifest-store.js. The two must agree
+on LOCK_SUFFIX and on the stale timeout, or they will not exclude each other.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Mirrored in lib/manifest-store.js — change both or neither.
+LOCK_SUFFIX = ".lock"
+LOCK_STALE_SECONDS = 30.0
+LOCK_TIMEOUT_SECONDS = 10.0
+LOCK_POLL_SECONDS = 0.05
+
+BACKUP_DIRNAME = "backups"
+BACKUP_KEEP = 30
+
+
+class ManifestCorrupt(RuntimeError):
+    """The manifest exists and could not be parsed.
+
+    Never caught into an empty manifest. The correct response to "I cannot read
+    the history" is to stop, not to declare there was none.
+    """
+
+
+class ManifestLocked(RuntimeError):
+    """Another writer held the lock longer than we are willing to wait."""
+
+
+def _lock_path(path: Path) -> Path:
+    return path.with_name(path.name + LOCK_SUFFIX)
+
+
+def acquire_lock(path: Path, timeout: float = LOCK_TIMEOUT_SECONDS) -> Path:
+    """Take the writer lock, or raise.
+
+    O_CREAT|O_EXCL is atomic on every filesystem this runs on, and unlike flock
+    it is visible to a Node process doing the same thing.
+    """
+    lock = _lock_path(path)
+    deadline = time.monotonic() + timeout
+
+    while True:
+        try:
+            fd = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+            os.write(fd, f"{os.getpid()} {time.time()}\n".encode())
+            os.close(fd)
+            return lock
+        except FileExistsError:
+            # A crashed writer must not wedge the voice forever.
+            try:
+                age = time.time() - lock.stat().st_mtime
+                if age > LOCK_STALE_SECONDS:
+                    lock.unlink(missing_ok=True)
+                    continue
+            except FileNotFoundError:
+                continue  # released while we looked
+            if time.monotonic() >= deadline:
+                raise ManifestLocked(
+                    f"another writer has held {lock.name} for longer than {timeout:.0f}s"
+                )
+            time.sleep(LOCK_POLL_SECONDS)
+
+
+def release_lock(lock: Path) -> None:
+    try:
+        lock.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def read_manifest(path: Path) -> dict:
+    """Parse the manifest, or raise ManifestCorrupt. Absent file is legitimately empty."""
+    if not path.exists():
+        return {"messages": []}
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as exc:
+        raise ManifestCorrupt(
+            f"{path} exists but did not parse ({exc}). Refusing to continue — "
+            f"writing now would replace the history with an empty file. "
+            f"A recent copy is in {path.parent / BACKUP_DIRNAME}/."
+        ) from exc
+
+    if not isinstance(data, dict) or not isinstance(data.get("messages"), list):
+        raise ManifestCorrupt(f"{path} parsed but is not a manifest ({{'messages': [...]}}).")
+    return data
+
+
+def _rotate_backup(path: Path, manifest: dict) -> None:
+    """Keep a daily copy. Best effort — a backup failure must never fail a publish."""
+    try:
+        backups = path.parent / BACKUP_DIRNAME
+        backups.mkdir(exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%d")
+        daily = backups / f"messages.{stamp}.json"
+        if not daily.exists() and path.exists():
+            shutil.copy2(path, daily)
+            keep = sorted(backups.glob("messages.*.json"))[:-BACKUP_KEEP]
+            for old in keep:
+                old.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+def write_manifest(path: Path, manifest: dict) -> None:
+    """Replace the manifest atomically. Caller must hold the lock."""
+    if not isinstance(manifest.get("messages"), list):
+        raise ValueError("refusing to write a manifest without a messages list")
+
+    _rotate_backup(path, manifest)
+
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())  # the bytes are on disk before the rename
+        os.replace(tmp, path)     # atomic: readers see old or new, never half
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+    # Durably record the rename itself, so a power loss cannot resurrect the old file.
+    try:
+        dfd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(dfd)
+        finally:
+            os.close(dfd)
+    except OSError:
+        pass
+
+
+def append_message(path: Path, entry: dict) -> int:
+    """Append one message under the lock. Returns the new record count."""
+    lock = acquire_lock(path)
+    try:
+        manifest = read_manifest(path)
+        manifest["messages"].append(entry)
+        write_manifest(path, manifest)
+        return len(manifest["messages"])
+    finally:
+        release_lock(lock)

--- a/scripts/test-manifest-durability.py
+++ b/scripts/test-manifest-durability.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Try to lose a record. Everything runs on a COPY in a temp dir."""
+import json, os, shutil, subprocess, sys, tempfile
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
+
+REPO = Path("/home/gmusic/salix/repos/assembly-voice")
+sys.path.insert(0, str(REPO / "scripts"))
+import manifest_store as ms
+
+work = Path(tempfile.mkdtemp(prefix="voice-breakit-"))
+M = work / "messages.json"
+
+def seed(n=101):
+    M.write_text(json.dumps({"messages": [{"id": f"seed-{i}", "text": f"m{i}"} for i in range(n)]}, indent=2))
+
+def count():
+    try:
+        return len(json.loads(M.read_text())["messages"])
+    except Exception as e:
+        return f"UNPARSEABLE ({type(e).__name__})"
+
+ok = lambda c: "✓" if c else "✗"
+results = []
+
+# ── 1 · the original bomb: torn file, then a normal publish ────────────────
+seed()
+before = count()
+raw = M.read_text(); M.write_text(raw[:5000])          # simulate interrupted write
+try:
+    ms.append_message(M, {"id": "after-tear", "text": "the next message"})
+    outcome = f"WROTE ANYWAY → {count()} records"; passed = False
+except ms.ManifestCorrupt as e:
+    outcome = "refused: " + str(e).split(".")[0][:58]; passed = True
+results.append(("torn file, then a publish", f"{before} → refused", ok(passed), outcome))
+
+# ── 2 · does the torn file survive for recovery? ──────────────────────────
+still_there = M.exists() and len(M.read_text()) == 5000
+results.append(("torn bytes preserved, not overwritten", "yes", ok(still_there), f"{len(M.read_text())} bytes intact"))
+
+# ── 3 · 8 concurrent publishers ───────────────────────────────────────────
+seed()
+def pub(i):
+    try:
+        ms.append_message(M, {"id": f"concurrent-{i}", "text": f"c{i}"}); return True
+    except Exception:
+        return False
+with ThreadPoolExecutor(max_workers=8) as ex:
+    wrote = sum(ex.map(pub, range(8)))
+final = count()
+passed = final == 109 and wrote == 8
+results.append(("8 concurrent publishers", "101 → 109", ok(passed), f"{final} records, {wrote}/8 wrote"))
+
+# ── 4 · Python and Node writing at the same time ──────────────────────────
+seed()
+node = f"""
+const store = require("{REPO}/lib/manifest-store");
+for (let i = 0; i < 6; i++) {{
+  store.updateManifest("{M}", (d) => {{ d.messages.push({{id:"node-"+i}}); return true; }});
+}}
+"""
+(work / "n.js").write_text(node)
+proc = subprocess.Popen(["node", str(work / "n.js")], cwd=str(REPO))
+with ThreadPoolExecutor(max_workers=6) as ex:
+    pywrote = sum(ex.map(lambda i: pub(100 + i), range(6)))
+proc.wait()
+final = count()
+passed = final == 113
+results.append(("Python + Node interleaved", "101 → 113", ok(passed), f"{final} records"))
+
+# ── 5 · killed mid-write leaves the old file whole ────────────────────────
+seed()
+before = count()
+killer = f"""
+import sys, os, signal, json
+sys.path.insert(0, "{REPO}/scripts")
+import manifest_store as ms
+from pathlib import Path
+M = Path("{M}")
+real = ms.write_manifest
+def bomb(path, manifest):
+    tmp = path.with_name("." + path.name + f".{{os.getpid()}}.tmp")
+    tmp.write_text(json.dumps(manifest)[:400])   # a half-written temp file
+    os.kill(os.getpid(), signal.SIGKILL)         # die before the rename
+ms.write_manifest = bomb
+try: ms.append_message(M, {{"id":"never"}})
+except Exception: pass
+"""
+(work / "k.py").write_text(killer)
+subprocess.run([sys.executable, str(work / "k.py")], capture_output=True)
+after = count()
+passed = after == before
+results.append(("killed before the rename", f"{before} intact", ok(passed), f"{after} records"))
+
+# ── 6 · the stale lock from a dead writer must not wedge the voice ────────
+seed()
+lock = Path(str(M) + ms.LOCK_SUFFIX)
+lock.write_text("99999 0\n")
+os.utime(lock, (0, 0))                                  # ancient
+try:
+    ms.append_message(M, {"id": "after-stale-lock"}); passed = count() == 102
+except Exception as e:
+    passed = False
+results.append(("stale lock is broken, not obeyed", "publish proceeds", ok(passed), f"{count()} records"))
+
+# ── 7 · a live lock is respected ──────────────────────────────────────────
+seed()
+held = ms.acquire_lock(M)
+try:
+    ms.append_message(M, {"id": "should-not-land"}, ) if False else None
+    try:
+        ms.acquire_lock(M, timeout=0.4); passed = False; note = "second writer got in"
+    except ms.ManifestLocked:
+        passed = True; note = "second writer waited then gave up"
+finally:
+    ms.release_lock(held)
+results.append(("a held lock excludes a second writer", "blocked", ok(passed), note))
+
+print(f"\n{'CASE':<42}{'EXPECTED':<20}{'':<3}{'ACTUAL'}")
+print("─" * 108)
+for case, exp, mark, act in results:
+    print(f"{case:<42}{exp:<20}{mark:<3}{act}")
+fails = sum(1 for r in results if r[2] == "✗")
+print("─" * 108)
+print(f"{len(results) - fails} passed · {fails} failed")
+shutil.rmtree(work, ignore_errors=True)
+sys.exit(1 if fails else 0)

--- a/scripts/tts-generate.py
+++ b/scripts/tts-generate.py
@@ -19,6 +19,11 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 import edge_tts
+
+# Local sibling module — the manifest is shared with server.js and must be
+# written the same careful way from both.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import manifest_store  # noqa: E402
 from dotenv import load_dotenv
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -222,14 +227,10 @@ async def amain() -> int:
     communicate = edge_tts.Communicate(args.text, voice)
     await communicate.save(out_path)
 
-    if MESSAGES_FILE.exists():
-        try:
-            with open(MESSAGES_FILE, encoding="utf-8") as f:
-                manifest = json.load(f)
-        except Exception:
-            manifest = {"messages": []}
-    else:
-        manifest = {"messages": []}
+    # The manifest is read, mutated and written under one cross-language lock in
+    # manifest_store.append_message below. Nothing is parsed here any more: the
+    # old code caught a parse failure into an empty manifest and then truncated
+    # the file, which is how 407 records could vanish on exit code 0.
 
     entry = {
         "id": str(uuid.uuid4()),
@@ -241,14 +242,24 @@ async def amain() -> int:
         "pwd": os.getcwd(),
         "listened": False,
     }
-    manifest["messages"].append(entry)
-
-    with open(MESSAGES_FILE, "w", encoding="utf-8") as f:
-        json.dump(manifest, f, indent=2, ensure_ascii=False)
-        f.write("\n")
+    # One lock, one atomic rename. If the manifest cannot be read, this raises
+    # rather than starting from an empty one — and if it raises, the audio we
+    # just wrote is removed, because a voice nobody can find is litter that the
+    # portal serves publicly forever. Two zero-byte orphans from the old
+    # behaviour are still on disk.
+    try:
+        total = manifest_store.append_message(MESSAGES_FILE, entry)
+    except Exception as exc:
+        try:
+            out_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        print(f"REFUSED  {exc}", file=sys.stderr)
+        print(f"         nothing was published, and {fname} was removed", file=sys.stderr)
+        return 1
 
     size = out_path.stat().st_size
-    print(f"OK  id={entry['id']}")
+    print(f"OK  id={entry['id']}  ({total} messages)")
     print(f"    persona={persona}  lang={lang}  voice={voice}")
     print(f"    audio={out_path}  bytes={size}")
     print(f"    public_url={PUBLIC_AUDIO_BASE}/{fname}")

--- a/server.js
+++ b/server.js
@@ -40,15 +40,42 @@ if (fs.existsSync(agentsDir)) {
   });
 }
 
+const store = require('./lib/manifest-store');
+
+/**
+ * Reads on the display path stay forgiving — a torn manifest should degrade the
+ * feed, never take the portal down. But it must not be mistaken for an empty
+ * history, so it is logged loudly and never handed to a writer.
+ */
 const readMessages = () => {
   try {
-    return JSON.parse(fs.readFileSync(MESSAGES_FILE, 'utf8'));
+    return store.readManifest(MESSAGES_FILE);
   } catch (e) {
-    return { messages: [] };
+    console.error(`[voice] manifest unreadable: ${e.message}`);
+    return { messages: [], degraded: true };
   }
 };
-const writeMessages = (data) => {
-  fs.writeFileSync(MESSAGES_FILE, JSON.stringify(data, null, 2) + '\n');
+
+/**
+ * Every write goes through updateManifest: one cross-language lock, a fresh
+ * read inside it, and an atomic rename. The read-inside-the-lock is what
+ * removes the lost update — previously this handler read the file, a publisher
+ * appended, and the handler then wrote its stale snapshot back, deleting the
+ * new message.
+ */
+const updateMessages = (res, mutate) => {
+  try {
+    return { ok: true, data: store.updateManifest(MESSAGES_FILE, mutate) };
+  } catch (e) {
+    const corrupt = e instanceof store.ManifestCorrupt;
+    console.error(`[voice] refusing to write: ${e.message}`);
+    res.status(corrupt ? 500 : 503).json({
+      error: corrupt
+        ? 'message history is unreadable — refusing to overwrite it'
+        : 'another writer is holding the message history; try again',
+    });
+    return { ok: false };
+  }
 };
 
 app.get('/api/agents', (req, res) => res.json(agents));
@@ -62,24 +89,32 @@ app.get('/api/messages/unlistened', (req, res) => {
 });
 
 app.post('/api/messages/:id/listened', (req, res) => {
-  const data = readMessages();
-  const msg = data.messages.find((m) => m.id === req.params.id);
-  if (!msg) return res.status(404).json({ error: 'Message not found' });
-  msg.listened = true;
-  writeMessages(data);
-  res.json({ ok: true, message: msg });
+  let found = null;
+  const result = updateMessages(res, (data) => {
+    found = data.messages.find((m) => m.id === req.params.id);
+    if (!found) return false;          // nothing to write — leave the file alone
+    if (found.listened) return false;  // already marked; do not rewrite 340KB
+    found.listened = true;
+    return true;
+  });
+  if (!result.ok) return;
+  if (!found) return res.status(404).json({ error: 'Message not found' });
+  res.json({ ok: true, message: found });
 });
 
 app.post('/api/messages/listen-all', (req, res) => {
-  const data = readMessages();
   let marked = 0;
-  data.messages.forEach((m) => {
-    if (!m.listened) {
-      m.listened = true;
-      marked += 1;
-    }
+  const result = updateMessages(res, (data) => {
+    marked = 0;
+    data.messages.forEach((m) => {
+      if (!m.listened) {
+        m.listened = true;
+        marked += 1;
+      }
+    });
+    return marked > 0;
   });
-  if (marked > 0) writeMessages(data);
+  if (!result.ok) return;
   res.json({ ok: true, marked });
 });
 


### PR DESCRIPTION
Groundwork for Gerico1007/assembly-voice#12. **This PR contains no provenance code** — it makes the file that provenance will be written into survive being written to.

## What is wrong today

`messages.json` holds **407 messages** going back to 2026-05-02. It is in `.gitignore` and untracked, so git has never seen one of them. Both writers shared the same two-step defect:

```
except Exception:  manifest = {"messages": []}     # substitute empty
open(MESSAGES_FILE, "w")                           # then truncate
```

An interrupted write leaves a torn file. The next **ordinary** operation — a publish, or a listener simply tapping "listened" — parses it, fails, silently starts from an empty manifest, and overwrites.

Reproduced on a copy:

| scenario | before |
|---|---|
| torn file, then one normal publish | **101 records → 1**, exit 0, prints "OK" |
| 8 concurrent publishers | **101 records → 4** |
| publish, then a listener taps "listened" | the new message is **deleted** |

None of this needs the new feature to happen. It is true right now.

## What this changes

Two mirrored modules — `scripts/manifest_store.py` and `lib/manifest-store.js` — enforce three rules:

1. **A corrupt manifest is never "empty."** It raises. An empty manifest is a claim that nothing was ever said, and this file cannot make that claim. The unreadable bytes are preserved for recovery instead of overwritten.
2. **Writes are atomic** — sibling temp file, `fsync`, `os.replace`/`rename`, then fsync the directory. A reader never sees a half-written manifest, so rule 1 stops being reachable at all.
3. **Writers take a lock.** Two languages write this file, so it is an `O_EXCL` sentinel rather than `flock` — Python and Node exclude *each other*. A lock older than 30s is treated as a crashed writer and broken, so a dead process cannot silence the voice.

Also:

- the `listened` handlers now read **inside** the lock, removing the lost update, and skip the write entirely when nothing changed rather than rewriting 340KB to set a flag that was already set
- **a refused publish now deletes the audio it already wrote.** The mp3 is saved before the record, so every failure left a file served publicly forever and referenced by nothing — two zero-byte orphans from that shape are already on disk
- backups rotate daily into `backups/`, kept 30; `backups/` added to `.gitignore` for the same reason `messages.json` is there — it is voice data, not source

## Verification

`scripts/test-manifest-durability.py` reproduces the original failures against a copy:

```
torn file, then a publish              101 → refused, torn bytes intact   ✓
torn bytes preserved, not overwritten  5000 bytes intact                  ✓
8 concurrent publishers                101 → 109, 8/8 wrote               ✓
Python + Node interleaved              101 → 113                          ✓
killed before the rename               101 intact                         ✓
stale lock broken, not obeyed          publish proceeds                   ✓
held lock excludes a second writer     blocked                            ✓
                                       7 passed · 0 failed
```

Read-only against the live file: both implementations read all **407** records; `messages.json` is unmodified (340392 bytes, mtime unchanged).

## Before merging

The portal running on `:4444` still has the old code loaded — this takes effect **on restart**, which was deliberately not done here. A restart is yours to choose.

🌸 Groundwork is the part nobody sees. This one is the floor under the room the new door opens into.