### PR TITLE
fix: restore the live feed, which the atomic-write fix silently killed

### DIFF
--- a/server.js
+++ b/server.js
@@ -123,7 +123,23 @@ app.use(express.static(path.join(ROOT, 'dist')));
 
 let watchTimer = null;
 let lastBroadcastId = null;
-fs.watch(MESSAGES_FILE, () => {
+
+/**
+ * Watch the DIRECTORY, not the file.
+ *
+ * fs.watch on a path binds to the inode behind it. Since writes became atomic
+ * (temp file, fsync, rename) the old inode is unlinked on every publish, so a
+ * file watch fires once for the rename and is then bound to something nobody
+ * will ever write to again. Measured: in-place write → 1 event; first rename →
+ * events; second rename → nothing, watcher dead.
+ *
+ * That is a regression the atomic-write fix introduced, and it is the quiet
+ * kind: the portal keeps serving, /api/messages stays correct, and only the
+ * live push stops — so the feed simply stops moving and nothing reports an
+ * error. A directory watch survives the rename because the directory's inode
+ * does not change.
+ */
+const broadcastLatest = () => {
   if (watchTimer) clearTimeout(watchTimer);
   watchTimer = setTimeout(() => {
     const data = readMessages();
@@ -134,6 +150,14 @@ fs.watch(MESSAGES_FILE, () => {
       console.log(`📨 broadcast new_message  persona=${latest.persona} lang=${latest.lang}`);
     }
   }, 200);
+};
+
+const MESSAGES_BASENAME = path.basename(MESSAGES_FILE);
+fs.watch(ROOT, (_event, filename) => {
+  // The temp file and the lock live in this directory too; only the manifest
+  // landing is news. A null filename means the platform did not tell us which
+  // file changed, in which case checking is cheaper than missing a message.
+  if (filename === null || filename === MESSAGES_BASENAME) broadcastLatest();
 });
 
 io.on('connection', (socket) => {


### PR DESCRIPTION
**Regression from #13, live on production now.** Please merge ahead of #14.

## What broke

#13 made manifest writes atomic — temp file, `fsync`, `rename`. `fs.watch` binds to the **inode** behind a path, and a rename unlinks it. So the watcher at `server.js:126` fired once for the first rename and was thereafter bound to a file nobody will ever write to again.

```
in-place write   → 1 event
first rename     → events
second rename    → nothing, watcher dead
```

**This is the quiet kind of regression.** The portal keeps serving, `/api/messages` stays correct, every message is safely on disk — only the socket.io `new_message` push stops. The feed simply stops moving and nothing reports an error.

Production has been in this state since #13 merged and the service restarted.

## The fix

Watch the **directory**, filter for the basename. A directory's inode does not change when a file inside it is replaced.

Five consecutive atomic writes — the real publish pattern:

```
directory watch fired : 5   ✓ still alive
file watch fired      : 3   ✗ died after the first rename
```

## Credit

Found by an adversarial review agent reading the diff **statically**, as a suspicion it explicitly could not run the code to confirm. It was right, and it said so as a suspicion rather than a finding — which is why it was worth checking.

🌸 The floor held. The doorbell stopped ringing, and nobody could hear the silence.